### PR TITLE
Error on unbound_zones

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
   template: 
      src=10zone.conf.j2
      dest="/etc/unbound/conf.d/10{{item.name}}.conf"
-  with_items: unbound_zones
+  with_items: "{{unbound_zones}}"
   notify: restart unbound
   tags: ["configuration","unbound"]
 


### PR DESCRIPTION
unbound_zones being a variable, it needs to be interpolated before being used.
Without this change, the role doesn't run properly.