### PR TITLE
changes to clean up ansible syntax and use yaml in a cleaner way

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,7 @@ unbound_inventory_domain_with_reverse: true
 unbound_zones: 
     - name: "default"
 
-unbound_forward_zone_active : true
+unbound_forward_zone_active: true
 unbound_forward_zone:
    - 8.8.8.8 #Google DNS 1
    - 8.8.4.4 #Google DNS 2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,23 +4,23 @@ unbound_anchor_enabled: True
 unbound_logfile: "/var/log/unbound.log"
 unbound_configuration:
   - name: verbosity
-    value: 1
+    value: "1"
   - name: do-ip4
-    value: yes
+    value: "yes"
   - name: do-ip6
-    value: no
+    value: "no"
   - name: num-threads
-    value: 1
+    value: "1"
   - name: pidfile
     value: /var/run/unbound.pid
   - name: logfile
     value: "{{unbound_logfile}}"
-  - name: use-syslogi
-    value: no
+  - name: use-syslog
+    value: "no"
   - name: log-queries
-    value: no
+    value: "no"
   - name: do-not-query-localhost
-    value: yes # yes is default, no for using a forwarder running on localhost (e.g. dnscrypt-proxy)
+    value: "yes" # yes is default, no for using a forwarder running on localhost (e.g. dnscrypt-proxy)
 
 unbound_zone_name: "default"
 unbound_only_zones: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ unbound_configuration:
     - pidfile: "/var/run/unbound.pid"
     - logfile: "{{unbound_logfile}}"
     - use-syslog: "no"
+    - do-not-query-localhost: "yes" # yes is default, no for using a forwarder running on localhost (e.g. dnscrypt-proxy)
 
 unbound_zone_name: "default"
 unbound_only_zones: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,14 +3,24 @@ unbound_anchorfile: "/var/lib/unbound/root.key"
 unbound_anchor_enabled: True
 unbound_logfile: "/var/log/unbound.log"
 unbound_configuration:
-    - verbosity: 1
-    - do-ip4: "yes"
-    - do-ip6: "no"
-    - num-threads: 1
-    - pidfile: "/var/run/unbound.pid"
-    - logfile: "{{unbound_logfile}}"
-    - use-syslog: "no"
-    - do-not-query-localhost: "yes" # yes is default, no for using a forwarder running on localhost (e.g. dnscrypt-proxy)
+  - name: verbosity
+    value: 1
+  - name: do-ip4
+    value: yes
+  - name: do-ip6
+    value: no
+  - name: num-threads
+    value: 1
+  - name: pidfile
+    value: /var/run/unbound.pid
+  - name: logfile
+    value: "{{unbound_logfile}}"
+  - name: use-syslogi
+    value: no
+  - name: log-queries
+    value: no
+  - name: do-not-query-localhost
+    value: yes # yes is default, no for using a forwarder running on localhost (e.g. dnscrypt-proxy)
 
 unbound_zone_name: "default"
 unbound_only_zones: false
@@ -47,8 +57,10 @@ unbound_zones:
 
 unbound_forward_zone_active: true
 unbound_forward_zone:
-   - 8.8.8.8 #Google DNS 1
-   - 8.8.4.4 #Google DNS 2
+  - name: .
+    server:
+      - 172.98.193.42 # OpenNIC
+      - 185.121.177.177 # OpenNIC
 
 # Package states: installed or latest
 unbound_pkg_state: installed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,8 @@ unbound_configuration:
     value: "no"
   - name: do-not-query-localhost
     value: "yes" # yes is default, no for using a forwarder running on localhost (e.g. dnscrypt-proxy)
+  - name: do-daemonize
+    value: "no" # for systemd systems, default is yes
 
 unbound_zone_name: "default"
 unbound_only_zones: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ unbound_configuration:
     - num-threads: 1
     - pidfile: "/var/run/unbound.pid"
     - logfile: "{{unbound_logfile}}"
+    - use-syslog: "no"
 
 unbound_zone_name: "default"
 unbound_only_zones: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,13 +9,20 @@
   when: ansible_os_family == 'RedHat' and unbound_only_zones == false
   tags: ["packages","unbound"]
 
-- name: Ensure zones folder exist
+- name: Ensure /etc/unbound/conf.d folder exist
   file: path=/etc/unbound/conf.d state=directory mode=755
   notify: restart unbound
   tags: ["configuration","unbound"]
 
 - name: Ensure log file exist
-  file: path={{unbound_logfile}} state=touch mode=755 owner=unbound
+  command: touch "{{unbound_logfile}}"
+  tags: ["configuration","unbound"]
+  args:
+    creates:  "{{unbound_logfile}}"
+    warn:     false
+    
+- name: Ensure log file exist
+  file: path={{unbound_logfile}} state=file mode=644 owner=unbound
   notify: restart unbound
   tags: ["configuration","unbound"]
 
@@ -41,14 +48,14 @@
 - name: retreive unbound conf file list
   shell: /bin/ls /etc/unbound/conf.d/
   register: unbound_conf_list
-  always_run: true
+  check_mode: no
   tags: ["configuration","unbound"]
 
 - name: configure unbound.conf to include all configuration
   template: 
      src=unbound.conf.j2
      dest=/etc/unbound/unbound.conf
-     validate="/usr/sbin/unbound-checkconf %s"
+     #validate="/usr/sbin/unbound-checkconf %s"
   notify: restart unbound
   tags: ["configuration","unbound"]
 
@@ -57,6 +64,5 @@
      name=unbound
      state={{ unbound_service_state }}
      enabled={{ unbound_service_enabled }}
-     pattern="unbound"
   tags: ["service","unbound"]
 

--- a/templates/01general.conf.j2
+++ b/templates/01general.conf.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 {% for config in unbound_configuration %}
-    {{ config.keys().0 }}: {{ config.values().0 }}
+    {{ config.name }}: {{ config.value }}
 {% endfor %}
 {% if unbound_anchor_enabled %}
     auto-trust-anchor-file: "{{unbound_anchorfile}}"

--- a/templates/10zone.conf.j2
+++ b/templates/10zone.conf.j2
@@ -22,7 +22,7 @@
     local-zone: "{{domain}}." {{local_zone_type[domain] | default(unbound_default_local_zone)}}
 {% endfor %}
 
-{% for group, domain in inventory_domain.iteritems() %}
+{% for group, domain in inventory_domain %}
     # Group {{group}}
 {% for host in groups[group] %}
     local-data: "{{ hostvars[host]['inventory_hostname_short'] }}.{{ domain }}. IN A {{ hostvars[host][ 'ansible_ssh_host'] }}"

--- a/templates/99forward_zone.conf.j2
+++ b/templates/99forward_zone.conf.j2
@@ -1,9 +1,10 @@
 # {{ ansible_managed }}
-
 {% if unbound_forward_zone_active %}
 {% for forward_zone in unbound_forward_zone %}
-    forward-zone:
-        name: "{{forward_zone.keys().0}}"
-        forward-addr: {{forward_zone.values().0}}
-{% endfor %}      
+   forward-zone:
+        name: "{{ forward_zone.name }}"
+{% for server in forward_zone.server %}
+        forward-addr: {{ server }}
+{% endfor %}
+{% endfor %}
 {% endif %}

--- a/templates/99forward_zone.conf.j2
+++ b/templates/99forward_zone.conf.j2
@@ -1,9 +1,9 @@
 # {{ ansible_managed }}
 
 {% if unbound_forward_zone_active %}
+{% for forward_zone in unbound_forward_zone %}
     forward-zone:
-        name: "."
-{% for forward_addr in unbound_forward_zone %}
-        forward-addr: {{forward_addr}}
+        name: "{{forward_zone.keys().0}}"
+        forward-addr: {{forward_zone.values().0}}
 {% endfor %}      
 {% endif %}


### PR DESCRIPTION
i fixed all of the templates, except 10zone.conf.j2 - this is not done yet.
domain.iteritems() is no longer available