### PR TITLE
Allow more complex structure for local domains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ install:
 script:
   - echo localhost > inventory
   - ansible-playbook -i inventory --syntax-check --list-tasks role.yml
-  - ansible-playbook -i inventory --connection=local --sudo -vvvv role.yml
+  - ansible-playbook -i inventory --connection=local --become-method sudo -vvvv role.yml
 notifications:
     webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ install:
 script:
   - echo localhost > inventory
   - ansible-playbook -i inventory --syntax-check --list-tasks role.yml
-  - ansible-playbook -i inventory --connection=local --become-method sudo -vvvv role.yml
+  - ansible-playbook -i inventory --connection=local --become --become-method sudo -vvvv role.yml
 notifications:
     webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ unbound_local_zone_type:
 
 For creating local domain data with the `unbound_domain` variable two variants can be used.
 The simple one uses plain strings to create one resource record per host name.
-With this variant no other resource records for the same name cna be created.
+With this variant no other resource records for the same name can be created.
 
-The more complex version allows objects to set the following resource records: `A`, 
+The more complex version allows dict objects to set the following resource records: `A`, 
 `AAAA`, `CNAME`, `TXT`. Reverse records are automatically created for `A` and `AAAA` if needed.
 
 Resource records for the domain itself may be set as a list with the `domain_rr` key. 
@@ -115,7 +115,7 @@ unbound_domain:
   domain_name: example.net
   domain_rr:
     - "MX 10 server1.example.net."
-    - "IN A 1.2.3.5 
+    - "IN A 1.2.3.5"
   www: "1.2.3.4"
   server1: "IN A 1.2.3.5"
   admin-contact: 'IN TXT "ask your neighbour"'  
@@ -169,7 +169,7 @@ Generated unbound configuration:
     local-data: 'admin-contact.example.net. IN TXT "ask your neighbour"'
 ```` 
 
-##### Example for mixed domain with booth versions:
+##### Example for mixed domain with both versions:
 ````yml
 unbound_domain:
   domain_name: example.net

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ansible role for Unbound DNS Server and resolver
 - Generation of DNS entries from ansible inventory (A entries and reverse)
 - Forward to another dns
 - IPv4/IPv6 for reverse
- (A, AAAA, CNAME, TXT, PTR
+
 # Information :
 - Test on Ubuntu
 - Untested on debian and fedora

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Ansible role for Unbound DNS Server and resolver
 
 
 # Supports
-- Add DNS entries
+- Add DNS entries (multiple record types per entry)
 - Generation of DNS entries from ansible inventory (A entries and reverse)
 - Forward to another dns
-- IPv4 only for reverse
-
+- IPv4/IPv6 for reverse
+ (A, AAAA, CNAME, TXT, PTR
 # Information :
 - Test on Ubuntu
 - Untested on debian and fedora
@@ -96,3 +96,103 @@ unbound_local_zone_type:
     reversed.example.com: "static"
 
 ```
+
+### Create local domain data
+
+For creating local domain data with the `unbound_domain` variable two variants can be used.
+The simple one uses plain strings to create one resource record per host name.
+With this variant no other resource records for the same name cna be created.
+
+The more complex version allows objects to set the following resource records: `A`, 
+`AAAA`, `CNAME`, `TXT`. Reverse records are automatically created for `A` and `AAAA` if needed.
+
+Resource records for the domain itself may be set as a list with the `domain_rr` key. 
+Attention - the domain name is not automatically added, the string is taken as is!  
+
+##### Example for simple domain:
+````yml
+unbound_domain:
+  domain_name: example.net
+  domain_rr:
+    - "MX 10 server1.example.net."
+    - "IN A 1.2.3.5 
+  www: "1.2.3.4"
+  server1: "IN A 1.2.3.5"
+  admin-contact: 'IN TXT "ask your neighbour"'  
+```` 
+
+Generated unbound configuration:
+````yml
+    local-zone: "example.net." static
+    local-data: "example.net. MX 10 server1.example.net."
+    local-data: "example.net. IN A 1.2.3.5"
+    local-data: "www.example.net. 1.2.3.4"
+    local-data: "server1.example.net. IN A 1.2.3.5"
+    local-data: 'admin-contact.example.net. IN TXT "ask your neighbour"'
+```` 
+
+##### Example for complex domain:
+
+All fields (ip, ipv6, cnames, txt, reverse) are optional, only the attributes needed
+should be set
+
+````yml
+unbound_domain:
+  domain_name: example.net
+  www:
+    ip: "1.2.3.4"
+    reverse: true
+  server1:
+    ip: "1.2.3.5"
+    ipv6: "fe80::7"
+    cnames:
+      - mail
+      - imap
+      - smtp
+    reverse: true
+  admin-contact:
+    txt: "ask your neighbour"  
+```` 
+
+Generated unbound configuration:
+````yml
+    local-zone: "example.net." static
+    local-data: "www.example.net. 1.2.3.4"
+    local-data-ptr: "1.2.3.4 www.example.net."
+    local-data: "server1.example.net. IN A  1.2.3.5"
+    local-data: "server1.example.net. IN AAAA fe80::7"
+    local-data: "mail.example.net. IN CNAME server1.example.net."
+    local-data: "imap.example.net. IN CNAME server1.example.net."
+    local-data: "smtp.example.net. IN CNAME server1.example.net."
+    local-data-ptr: "1.2.3.5 server1.example.net."
+    local-data-ptr: "fe80::7 server1.example.net."
+    local-data: 'admin-contact.example.net. IN TXT "ask your neighbour"'
+```` 
+
+##### Example for mixed domain with booth versions:
+````yml
+unbound_domain:
+  domain_name: example.net
+  www: "1.2.3.4"
+  server1:
+    ip: "1.2.3.5"
+    ipv6: "fe80::7"
+    cnames:
+      - mail
+      - imap
+      - smtp
+    reverse: true
+```` 
+
+Generated unbond configuration:
+````yml
+    local-zone: "example.net." static
+    local-data: "www.example.net. 1.2.3.4"
+    local-data: "server1.example.net. IN A  1.2.3.5"
+    local-data: "server1.example.net. IN AAAA fe80::7"
+    local-data: "mail.example.net. IN CNAME server1.example.net."
+    local-data: "imap.example.net. IN CNAME server1.example.net."
+    local-data: "smtp.example.net. IN CNAME server1.example.net."
+    local-data-ptr: "1.2.3.5 server1.example.net."
+    local-data-ptr: "fe80::7 server1.example.net."
+```` 

--- a/templates/10zone.conf.j2
+++ b/templates/10zone.conf.j2
@@ -35,8 +35,34 @@
 {% for domain in domains %}
     local-zone: "{{domain.domain_name}}." {{local_zone_type[domain.domain_name] | default(unbound_default_local_zone)}}
 {% for subdomain, entry in domain.iteritems() %}
-{% if subdomain != "domain_name" %}
-    local-data: "{{ subdomain }}.{{ domain.domain_name }}. {{ entry }}"
+{% if subdomain == "domain_rr" %}
+{% for rr in entry %}
+    local-data:     "{{ domain.domain_name }}. {{ rr }}"
+{% endfor %}
+{% elif subdomain != "domain_name" %}
+{% if entry is string %}
+    local-data:     "{{ subdomain }}.{{ domain.domain_name }}. {{ entry }}"
+{% else %}
+{% set entry_ttl = entry.ttl | default('') %}
+{% if entry.ip is string %}
+    local-data:     "{{ subdomain }}.{{ domain.domain_name }}. IN A {{ entry_ttl }} {{ entry.ip }}"
+{% endif %}
+{% if entry.ipv6 is string %}
+    local-data:     "{{ subdomain }}.{{ domain.domain_name }}. IN AAAA {{ entry_ttl }} {{ entry.ipv6 }}"
+{% endif %}
+{% if entry.txt is string %}
+    local-data:     '{{ subdomain }}.{{ domain.domain_name }}. IN TXT {{ entry_ttl }} "{{ entry.txt }}"'
+{% endif %}
+{% for cname in (entry.cnames | default([])) %}
+    local-data:     "{{ cname }}.{{ domain.domain_name }}. IN CNAME {{ entry_ttl }} {{ subdomain }}.{{ domain.domain_name }}."
+{% endfor %}
+{% if entry.reverse | default(false) and entry.ip is string %}
+    local-data-ptr: "{{ entry.ip }} {{ entry_ttl }} {{ subdomain }}.{{ domain.domain_name }}."
+{% endif %}
+{% if entry.reverse | default(false) and entry.ipv6 is string %}
+    local-data-ptr: "{{ entry.ipv6 }} {{ entry_ttl }} {{ subdomain }}.{{ domain.domain_name }}."
+{% endif %}
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
The old version allows only a single resource record per entry. This patch modifies
the "unbound_domain" list to allow either a simple string as record like before or
a dict object to set multiple values per key.

With the new "domain_rr" key it is possible to set records for the domain itself too (like NS, MX or A records).

The readme is updated with examples showing the new possibilities.