### PR TITLE
Initial support for stub zones

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,6 +62,9 @@ unbound_forward_zone:
     # quadrant resolver
     - "12.159.2.159@853#dns-tls.qis.io"
 
+unbound_stub_zone_active: false
+unbound_stub_zone: {}
+
 # Package states: installed or latest
 unbound_pkg_state: present
 
@@ -70,4 +73,3 @@ unbound_service_state: started
 
 # Service enabled on startup: yes or no
 unbound_service_enabled: yes
-

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,5 @@
 - name: reload unbound
   service: name=unbound state=reloaded
 
+- name: reload apparmor
+  command: apparmor_parser -r /etc/apparmor.d/usr.sbin.unbound

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,7 @@
      dest="/etc/unbound/conf.d/{{item}}"
   with_items:
      - 01general.conf
+     - 98stub_zone.conf
      - 99forward_zone.conf
   notify: restart unbound
   when: unbound_only_zones == false
@@ -75,4 +76,3 @@
      enabled={{ unbound_service_enabled }}
      pattern="unbound"
   tags: ["service","unbound"]
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,16 @@
   notify: restart unbound
   tags: ["configuration","unbound"]
 
+- name: Configure AppArmor for the log file
+  template:
+     src=usr.sbin.unbound.j2
+     dest="/etc/apparmor.d/local/usr.sbin.unbound"
+  notify:
+    - restart unbound
+    - reload apparmor
+  when: unbound_only_zones == false
+  tags: ["configuration","unbound"]
+
 - name: configure add independant config file
   template:
      src={{item}}.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,13 @@
   tags: ["configuration","unbound"]
 
 - name: Ensure log file exist
-  file: path={{unbound_logfile}} state=touch mode=755 owner=unbound
+  file:
+    path: "{{ unbound_logfile }}"
+    state: touch
+    mode: 0644
+    owner: unbound
+    modification_time: preserve
+    access_time: preserve
   notify: restart unbound
   tags: ["configuration","unbound"]
 

--- a/templates/98stub_zone.conf.j2
+++ b/templates/98stub_zone.conf.j2
@@ -1,0 +1,11 @@
+# {{ ansible_managed }}
+
+{% if unbound_stub_zone_active %}
+{% for stub_zone in unbound_stub_zone %}
+    stub-zone:
+      name: "{{ stub_zone.name }}"
+      {% for stub_addr in stub_zone.addr -%}
+      stub-addr: {{ stub_addr }}
+      {% endfor %}
+{% endfor %}
+{% endif %}

--- a/templates/usr.sbin.unbound.j2
+++ b/templates/usr.sbin.unbound.j2
@@ -1,0 +1,2 @@
+# vim:syntax=apparmor
+{{ unbound_logfile }} rw,


### PR DESCRIPTION
This PR is mainly for adding functionality to handle stub zones (handy when used with Consul for example), but additionally makes log file creation in idempotent way + ensuring that AppArmor doesn’t prevent Unbound from using that log file.