### PR TITLE
Add support for rockylinux

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: install unbound for RedHat OS family
   yum: name=unbound state={{ unbound_pkg_state }}
-  when: ansible_os_family == 'RedHat' and unbound_only_zones == false
+  when: (ansible_os_family == 'RedHat' or ansible_os_family == 'Rocky')and unbound_only_zones == false
   tags: ["packages","unbound"]
 
 - name: Ensure zones folder exist


### PR DESCRIPTION
Ansible needs to apply the redhat policy to be supported for RockyLinux (tested on RockyLinux 8).